### PR TITLE
[BUG] 홈페이지 버튼 영역(테이블뷰) 스크롤 불가능하도록

### DIFF
--- a/WhatToDo/HomePage/HomePageViewController.swift
+++ b/WhatToDo/HomePage/HomePageViewController.swift
@@ -114,6 +114,9 @@ class HomePageViewController: UIViewController {
     }
     
     private func setupConstraints() {
+        tableView.isScrollEnabled = false
+
+        
         topBoxView.snp.makeConstraints { (make) in
             make.top.equalTo(self.view.snp.top)
             make.left.equalTo(self.view.snp.left)


### PR DESCRIPTION
tableView.isScrollEnabled = false
속성을 추가하여 스크롤 불가능하도록 하였음. 

close #11 